### PR TITLE
PR into master from update/mathpix-markdown-it-1.0.84

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"eslint-plugin-import": "^2.22.1",
 				"eslint-plugin-node": "^11.1.0",
 				"eslint-plugin-promise": "^4.2.1",
-				"mathpix-markdown-it": "^1.0.83",
+				"mathpix-markdown-it": "^1.0.84",
 				"webpack": "^4.43.0",
 				"webpack-cli": "^3.3.11"
 			},
@@ -4379,9 +4379,9 @@
 			}
 		},
 		"node_modules/mathpix-markdown-it": {
-			"version": "1.0.83",
-			"resolved": "https://registry.npmjs.org/mathpix-markdown-it/-/mathpix-markdown-it-1.0.83.tgz",
-			"integrity": "sha512-sKiAAKfckqvQ1xVOM90uTbe0QAYx+deTla4ljwzyNpiPOW02HWh4EdFDaPFS/3sZhv0oBnyvSRv25QKR33u52Q==",
+			"version": "1.0.84",
+			"resolved": "https://registry.npmjs.org/mathpix-markdown-it/-/mathpix-markdown-it-1.0.84.tgz",
+			"integrity": "sha512-f/MqjFDZn/xR3NyJTUUL53deHWkn9tVs1Y4Ktsct3jUNrxyx6B9TxYO2KmJqMeeJbOY1x1ks13mnY6x9aPB7RA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.17.2",
@@ -11659,9 +11659,9 @@
 			}
 		},
 		"mathpix-markdown-it": {
-			"version": "1.0.83",
-			"resolved": "https://registry.npmjs.org/mathpix-markdown-it/-/mathpix-markdown-it-1.0.83.tgz",
-			"integrity": "sha512-sKiAAKfckqvQ1xVOM90uTbe0QAYx+deTla4ljwzyNpiPOW02HWh4EdFDaPFS/3sZhv0oBnyvSRv25QKR33u52Q==",
+			"version": "1.0.84",
+			"resolved": "https://registry.npmjs.org/mathpix-markdown-it/-/mathpix-markdown-it-1.0.84.tgz",
+			"integrity": "sha512-f/MqjFDZn/xR3NyJTUUL53deHWkn9tVs1Y4Ktsct3jUNrxyx6B9TxYO2KmJqMeeJbOY1x1ks13mnY6x9aPB7RA==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.17.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"author": "Mathpix",
 	"displayName": "Mathpix Markdown",
 	"description": "Enable rendering Mathpix Markdown with latex and chemistry support.",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"publisher": "mathpix",
 	"repository": {
 		"type": "git",
@@ -83,7 +83,7 @@
 		"eslint-plugin-import": "^2.22.1",
 		"eslint-plugin-node": "^11.1.0",
 		"eslint-plugin-promise": "^4.2.1",
-		"mathpix-markdown-it": "^1.0.83",
+		"mathpix-markdown-it": "^1.0.84",
 		"webpack": "^4.43.0",
 		"webpack-cli": "^3.3.11"
 	}


### PR DESCRIPTION
branch: update/mathpix-markdown-it-1.0.84

- Updated [mathpix-markdown-it@1.0.84](https://www.npmjs.com/package/mathpix-markdown-it) to support unnumbered sections `\section*{}` 

https://github.com/Mathpix/mathpix-markdown-it/blob/master/doc/sections.md


<img width="1009" alt="Screen Shot 2023-01-21 at 11 14 10" src="https://user-images.githubusercontent.com/32493105/213860642-591fe485-b160-406e-9897-fca87492b6d9.png">

