### PR TITLE
PR into master from feature/vscode-mathpix-markdown/fix-padding-for-code-block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-mathpix-markdown",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-mathpix-markdown",
-			"version": "0.1.6",
+			"version": "0.1.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^12.12.0",
@@ -15,7 +15,7 @@
 				"eslint-plugin-import": "^2.22.1",
 				"eslint-plugin-node": "^11.1.0",
 				"eslint-plugin-promise": "^4.2.1",
-				"mathpix-markdown-it": "1.2.13",
+				"mathpix-markdown-it": "1.2.16",
 				"webpack": "^4.43.0",
 				"webpack-cli": "^3.3.11"
 			},
@@ -4175,9 +4175,9 @@
 			}
 		},
 		"node_modules/mathpix-markdown-it": {
-			"version": "1.2.13",
-			"resolved": "https://registry.npmjs.org/mathpix-markdown-it/-/mathpix-markdown-it-1.2.13.tgz",
-			"integrity": "sha512-8EUeHiQbLg2k6TdPIp7c+wJleXpcqDRqZ8YdxiuJmpD3G7t8pB+HHTwh9grKmUGSi/syFRtauhZOQLRXY6Gq9A==",
+			"version": "1.2.16",
+			"resolved": "https://registry.npmjs.org/mathpix-markdown-it/-/mathpix-markdown-it-1.2.16.tgz",
+			"integrity": "sha512-yLpqFnq3soZn3qKF1oEQBlS5zV7dBgZnpE1Yjf2VpzLqxOfjHMyHBx61U4sDLjD224uRv7TnIMfSx0rZS8JuQg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.17.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"author": "Mathpix",
 	"displayName": "Mathpix Markdown",
 	"description": "Enable rendering Mathpix Markdown with latex and chemistry support.",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"publisher": "mathpix",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"eslint-plugin-import": "^2.22.1",
 		"eslint-plugin-node": "^11.1.0",
 		"eslint-plugin-promise": "^4.2.1",
-		"mathpix-markdown-it": "1.2.13",
+		"mathpix-markdown-it": "1.2.16",
 		"webpack": "^4.43.0",
 		"webpack-cli": "^3.3.11"
 	}


### PR DESCRIPTION
branch: feature/vscode-mathpix-markdown/fix-padding-for-code-block

### Why:

- Updated [mathpix-markdown-it@1.2.16](https://github.com/Mathpix/mathpix-markdown-it/releases/tag/v1.2.16)

### What's being changed:

Before:
<img width="1196" alt="Screen Shot 2023-10-17 at 18 08 39" src="https://github.com/Mathpix/mathpix-markdown-it/assets/32493105/dc058a28-b1e3-41c9-a587-eaef19f26209">


After:

<img width="1186" alt="Screen Shot 2023-10-17 at 18 07 58" src="https://github.com/Mathpix/mathpix-markdown-it/assets/32493105/0f87de1b-f745-443a-b234-dd633caceb41">