### PR TITLE
[vscode-mathpix-markdown] PR into master from feature/vscode-mathpix-markdown/30-Conflict-with-bierner-markdown-mermaid-extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-mathpix-markdown",
-	"version": "0.1.9",
+	"version": "0.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-mathpix-markdown",
-			"version": "0.1.9",
+			"version": "0.2.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^12.12.0",
@@ -15,7 +15,7 @@
 				"eslint-plugin-import": "^2.22.1",
 				"eslint-plugin-node": "^11.1.0",
 				"eslint-plugin-promise": "^4.2.1",
-				"mathpix-markdown-it": "2.0.5",
+				"mathpix-markdown-it": "github:Mathpix/mathpix-markdown-it#dev/olga/12358-fix-tabular-rendering",
 				"webpack": "^4.43.0",
 				"webpack-cli": "^3.3.11"
 			},
@@ -4114,10 +4114,10 @@
 			}
 		},
 		"node_modules/mathpix-markdown-it": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/mathpix-markdown-it/-/mathpix-markdown-it-2.0.5.tgz",
-			"integrity": "sha512-MQL8PJZ4i6o8i+zLDw1aU3O4vtqM7qimRzpK0UE6rPJ/laY8n84qunZQ9Dx6uu/ah7fozm6jMLD5vz4/HLYa0Q==",
+			"version": "2.0.7",
+			"resolved": "git+ssh://git@github.com/Mathpix/mathpix-markdown-it.git#3d9e72fff35f05d87af1122ce6f2da5bc9c8a00d",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.17.2",
 				"@mathpix/domino": "2.1.8",
@@ -4142,6 +4142,7 @@
 				"mathjax-full": "3.2.2",
 				"mdurl": "^1.0.1",
 				"node-polyfill-webpack-plugin": "^1.1.4",
+				"opentype.js": "^1.3.4",
 				"parse-srcset": "^1.0.2",
 				"postcss": "^7.0.36",
 				"punycode": "^2.1.1",
@@ -4773,6 +4774,22 @@
 			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/opentype.js": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.4.tgz",
+			"integrity": "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==",
+			"dev": true,
+			"dependencies": {
+				"string.prototype.codepointat": "^0.2.1",
+				"tiny-inflate": "^1.0.3"
+			},
+			"bin": {
+				"ot": "bin/ot"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
 			}
 		},
 		"node_modules/optionator": {
@@ -6043,6 +6060,12 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
+		"node_modules/string.prototype.codepointat": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+			"integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+			"dev": true
+		},
 		"node_modules/string.prototype.trimend": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
@@ -6210,6 +6233,12 @@
 			"engines": {
 				"node": ">=0.6.0"
 			}
+		},
+		"node_modules/tiny-inflate": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+			"integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+			"dev": true
 		},
 		"node_modules/to-arraybuffer": {
 			"version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"eslint-plugin-import": "^2.22.1",
 				"eslint-plugin-node": "^11.1.0",
 				"eslint-plugin-promise": "^4.2.1",
-				"mathpix-markdown-it": "github:Mathpix/mathpix-markdown-it#dev/olga/12358-fix-tabular-rendering",
+				"mathpix-markdown-it": "2.0.7",
 				"webpack": "^4.43.0",
 				"webpack-cli": "^3.3.11"
 			},
@@ -4115,9 +4115,9 @@
 		},
 		"node_modules/mathpix-markdown-it": {
 			"version": "2.0.7",
-			"resolved": "git+ssh://git@github.com/Mathpix/mathpix-markdown-it.git#3d9e72fff35f05d87af1122ce6f2da5bc9c8a00d",
+			"resolved": "https://registry.npmjs.org/mathpix-markdown-it/-/mathpix-markdown-it-2.0.7.tgz",
+			"integrity": "sha512-Gex1tlz/udSxbBvqW/SVq3KHq2q7RpO2McDm5LkPc8aL4PK6Mc6FVXA3jqtkM9dnpMiFVxZBeIXrvUKTlxw/Iw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.17.2",
 				"@mathpix/domino": "2.1.8",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"eslint-plugin-import": "^2.22.1",
 		"eslint-plugin-node": "^11.1.0",
 		"eslint-plugin-promise": "^4.2.1",
-		"mathpix-markdown-it": "github:Mathpix/mathpix-markdown-it#dev/olga/12358-fix-tabular-rendering",
+		"mathpix-markdown-it": "2.0.7",
 		"webpack": "^4.43.0",
 		"webpack-cli": "^3.3.11"
 	}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"author": "Mathpix",
 	"displayName": "Mathpix Markdown",
 	"description": "Enable rendering Mathpix Markdown with latex and chemistry support.",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"publisher": "mathpix",
 	"repository": {
 		"type": "git",
@@ -83,7 +83,7 @@
 		"eslint-plugin-import": "^2.22.1",
 		"eslint-plugin-node": "^11.1.0",
 		"eslint-plugin-promise": "^4.2.1",
-		"mathpix-markdown-it": "2.0.5",
+		"mathpix-markdown-it": "github:Mathpix/mathpix-markdown-it#dev/olga/12358-fix-tabular-rendering",
 		"webpack": "^4.43.0",
 		"webpack-cli": "^3.3.11"
 	}


### PR DESCRIPTION
branch: `feature/vscode-mathpix-markdown/30-Conflict-with-bierner-markdown-mermaid-extension`

- Updated [mathpix-markdown-it@2.0.7](https://github.com/Mathpix/mathpix-markdown-it/pull/356)

### Fixes in mmd:

- Conflict with bierner.markdown-mermaid extension [#30](https://github.com/Mathpix/vscode-mathpix-markdown/issues/30)

~~~
```mermaid
graph TD;
    A-->B;
    A-->C;
    B-->D;
    C-->D;
```

::: mermaid
graph TD;
    A-->B;
    A-->C;
    B-->D;
    C-->D;
:::

# Header

<smiles>C</smiles>

\title{Title}

\section{Section}

```js
var foo = function (bar) {
  return bar++;
};
```
~~~

Before:

<img width="1119" alt="Screenshot 2024-11-18 at 13 02 41" src="https://github.com/user-attachments/assets/82e3fa84-3884-4dc5-b470-dc4594f69745">


After:

<img width="1165" alt="Screenshot 2024-11-18 at 13 03 20" src="https://github.com/user-attachments/assets/05b2c38b-9ed5-4f3d-b762-054698cffad0">

